### PR TITLE
Support for Caddyfile

### DIFF
--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -25,7 +25,7 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 	for nesting := d.Nesting(); d.NextBlock(nesting); {
 		key := d.Val()
 
-		log.Printf("key: %v", key
+		log.Printf("key: %v", key)
 		switch key {
 		case "mode":
 			if !d.NextArg() {

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -1,6 +1,7 @@
 package revocation
 
 import (
+	"log"
 	"strconv"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -21,9 +22,10 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 	c.CRLConfig = &crlConfg
 	c.OCSPConfig = &ocspConfig
 
-	for d.Next() {
+	for nesting := d.Nesting(); d.NextBlock(nesting); {
 		key := d.Val()
 
+		log.Printf("key: %v", key
 		switch key {
 		case "mode":
 			if !d.NextArg() {

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -1,7 +1,6 @@
 package revocation
 
 import (
-	"log"
 	"strconv"
 
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -96,7 +95,7 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 
 					crlConfg.TrustedSignatureCertsFiles = append(crlConfg.TrustedSignatureCertsFiles, d.Val())
 				default:
-					return nil, d.Errf("unknown subdirective for the crl config in the revocation verifier: %s", h.Val())
+					return d.Errf("unknown subdirective for the crl config in the revocation verifier: %s", d.Val())
 				}
 			}
 		case "ocsp_config":
@@ -122,11 +121,11 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 					ocspConfig.OCSPAIAStrict = false
 
 				default:
-					return nil, d.Errf("unknown subdirective for the ocsp config in the revocation verifier: %s", h.Val())
+					return d.Errf("unknown subdirective for the ocsp config in the revocation verifier: %s", d.Val())
 				}
 			}
 		default:
-			return nil, d.Errf("unknown subdirective for the revocation verifier: %s", h.Val())
+			return d.Errf("unknown subdirective for the revocation verifier: %s", key)
 		}
 
 	}

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -59,7 +59,6 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 							return d.ArgErr()
 						}
 						crlConfg.CDPConfig.CRLCDPStrict = b
-						// ...
 					case "storage_type":
 						if !d.NextArg() {
 							return d.ArgErr()

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -21,115 +21,115 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 	}
 	c.CRLConfig = &crlConfg
 	c.OCSPConfig = &ocspConfig
+	for d.Next() {
+		for nesting := d.Nesting(); d.NextBlock(nesting); {
+			key := d.Val()
 
-	for nesting := d.Nesting(); d.NextBlock(nesting); {
-		key := d.Val()
-
-		log.Printf("key: %v", key)
-		switch key {
-		case "mode":
-			if !d.NextArg() {
-				return d.ArgErr()
-			}
-
-			c.Mode = d.Val()
-
-		case "crl_config":
-			for nesting := d.Nesting(); d.NextBlock(nesting); {
-				switch d.Val() {
-				case "work_dir":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.WorkDir = d.Val()
-				case "crl_fetch_mode":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.CDPConfig.CRLFetchMode = d.Val()
-				case "crl_cdp_strict":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					b, err := strconv.ParseBool(d.Val())
-					if err != nil {
-						return d.ArgErr()
-					}
-					crlConfg.CDPConfig.CRLCDPStrict = b
-					// ...
-				case "storage_type":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.StorageType = d.Val()
-				case "update_interval":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.UpdateInterval = d.Val()
-				case "signature_validation_mode":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.SignatureValidationMode = d.Val()
-				case "crl_url":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.CRLUrls = append(crlConfg.CRLUrls, d.Val())
-				case "crl_file":
-					if !d.NextArg() {
-						return d.ArgErr()
-					}
-
-					crlConfg.CRLFiles = append(crlConfg.CRLFiles, d.Val())
-				case "trusted_signature_cert_file":
-					if !d.NextArg() {
-						return nil
-					}
-
-					crlConfg.TrustedSignatureCertsFiles = append(crlConfg.TrustedSignatureCertsFiles, d.Val())
-				default:
-					return d.Errf("unknown subdirective for the crl config in the revocation verifier: %s", d.Val())
+			log.Printf("key: %v", key)
+			switch key {
+			case "mode":
+				if !d.NextArg() {
+					return d.ArgErr()
 				}
-			}
-		case "ocsp_config":
-			for nesting := d.Nesting(); d.NextBlock(nesting); {
-				switch d.Val() {
-				case "default_cache_duration":
-					if !d.NextArg() {
-						return nil
+
+				c.Mode = d.Val()
+
+			case "crl_config":
+				for nesting := d.Nesting(); d.NextBlock(nesting); {
+					switch d.Val() {
+					case "work_dir":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.WorkDir = d.Val()
+					case "crl_fetch_mode":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.CDPConfig.CRLFetchMode = d.Val()
+					case "crl_cdp_strict":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						b, err := strconv.ParseBool(d.Val())
+						if err != nil {
+							return d.ArgErr()
+						}
+						crlConfg.CDPConfig.CRLCDPStrict = b
+						// ...
+					case "storage_type":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.StorageType = d.Val()
+					case "update_interval":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.UpdateInterval = d.Val()
+					case "signature_validation_mode":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.SignatureValidationMode = d.Val()
+					case "crl_url":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.CRLUrls = append(crlConfg.CRLUrls, d.Val())
+					case "crl_file":
+						if !d.NextArg() {
+							return d.ArgErr()
+						}
+
+						crlConfg.CRLFiles = append(crlConfg.CRLFiles, d.Val())
+					case "trusted_signature_cert_file":
+						if !d.NextArg() {
+							return nil
+						}
+
+						crlConfg.TrustedSignatureCertsFiles = append(crlConfg.TrustedSignatureCertsFiles, d.Val())
+					default:
+						return d.Errf("unknown subdirective for the crl config in the revocation verifier: %s", d.Val())
 					}
-
-					ocspConfig.DefaultCacheDuration = d.Val()
-				case "trusted_responder_cert_file":
-					if !d.NextArg() {
-						return nil
-					}
-
-					ocspConfig.TrustedResponderCertsFiles = append(ocspConfig.TrustedResponderCertsFiles, d.Val())
-				case "ocsp_aia_strict":
-					if !d.NextArg() {
-						return nil
-					}
-
-					ocspConfig.OCSPAIAStrict = false
-
-				default:
-					return d.Errf("unknown subdirective for the ocsp config in the revocation verifier: %s", d.Val())
 				}
+			case "ocsp_config":
+				for nesting := d.Nesting(); d.NextBlock(nesting); {
+					switch d.Val() {
+					case "default_cache_duration":
+						if !d.NextArg() {
+							return nil
+						}
+
+						ocspConfig.DefaultCacheDuration = d.Val()
+					case "trusted_responder_cert_file":
+						if !d.NextArg() {
+							return nil
+						}
+
+						ocspConfig.TrustedResponderCertsFiles = append(ocspConfig.TrustedResponderCertsFiles, d.Val())
+					case "ocsp_aia_strict":
+						if !d.NextArg() {
+							return nil
+						}
+
+						ocspConfig.OCSPAIAStrict = false
+
+					default:
+						return d.Errf("unknown subdirective for the ocsp config in the revocation verifier: %s", d.Val())
+					}
+				}
+			default:
+				return d.Errf("unknown subdirective for the revocation verifier: %s", key)
 			}
-		default:
-			return d.Errf("unknown subdirective for the revocation verifier: %s", key)
 		}
-
 	}
 	return nil
 }

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -1,0 +1,128 @@
+package revocation
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/gr33nbl00d/caddy-revocation-validator/config"
+)
+
+func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	// initialize structs
+	crlConfg := config.CRLConfig{
+		CDPConfig:                  &config.CDPConfig{},
+		CRLUrls:                    []string{},
+		CRLFiles:                   []string{},
+		TrustedSignatureCertsFiles: []string{},
+	}
+	ocspConfig := config.OCSPConfig{
+		TrustedResponderCertsFiles: []string{},
+	}
+	c.CRLConfig = &crlConfg
+	c.OCSPConfig = &ocspConfig
+
+	for d.Next() {
+		key := d.Val()
+
+		log.Printf("key: %v", key)
+		switch key {
+		case "mode":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+
+			c.Mode = d.Val()
+
+		case "crl_config":
+			for nesting := d.Nesting(); d.NextBlock(nesting); {
+				switch d.Val() {
+				case "work_dir":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.WorkDir = d.Val()
+				case "crl_fetch_mode":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.CDPConfig.CRLFetchMode = d.Val()
+				case "crl_cdp_strict":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					b, err := strconv.ParseBool(d.Val())
+					if err != nil {
+						return d.ArgErr()
+					}
+					crlConfg.CDPConfig.CRLCDPStrict = b
+					// ...
+				case "storage_type":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.StorageType = d.Val()
+				case "update_interval":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.UpdateInterval = d.Val()
+				case "signature_validation_mode":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.SignatureValidationMode = d.Val()
+				case "crl_url":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.CRLUrls = append(crlConfg.CRLUrls, d.Val())
+				case "crl_file":
+					if !d.NextArg() {
+						return d.ArgErr()
+					}
+
+					crlConfg.CRLFiles = append(crlConfg.CRLFiles, d.Val())
+				case "trusted_signature_cert_file":
+					if !d.NextArg() {
+						return nil
+					}
+
+					crlConfg.TrustedSignatureCertsFiles = append(crlConfg.TrustedSignatureCertsFiles, d.Val())
+				}
+			}
+		case "ocsp_config":
+			for nesting := d.Nesting(); d.NextBlock(nesting); {
+				switch d.Val() {
+				case "default_cache_duration":
+					if !d.NextArg() {
+						return nil
+					}
+
+					ocspConfig.DefaultCacheDuration = d.Val()
+				case "trusted_responder_cert_file":
+					if !d.NextArg() {
+						return nil
+					}
+
+					ocspConfig.TrustedResponderCertsFiles = append(ocspConfig.TrustedResponderCertsFiles, d.Val())
+				case "ocsp_aia_strict":
+					if !d.NextArg() {
+						return nil
+					}
+
+					ocspConfig.OCSPAIAStrict = false
+
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/caddyUnmarshal.go
+++ b/caddyUnmarshal.go
@@ -25,7 +25,6 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 	for d.Next() {
 		key := d.Val()
 
-		log.Printf("key: %v", key)
 		switch key {
 		case "mode":
 			if !d.NextArg() {
@@ -96,6 +95,8 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 					}
 
 					crlConfg.TrustedSignatureCertsFiles = append(crlConfg.TrustedSignatureCertsFiles, d.Val())
+				default:
+					return nil, d.Errf("unknown subdirective for the crl config in the revocation verifier: %s", h.Val())
 				}
 			}
 		case "ocsp_config":
@@ -120,9 +121,14 @@ func (c *CertRevocationValidator) UnmarshalCaddyfile(d *caddyfile.Dispenser) err
 
 					ocspConfig.OCSPAIAStrict = false
 
+				default:
+					return nil, d.Errf("unknown subdirective for the ocsp config in the revocation verifier: %s", h.Val())
 				}
 			}
+		default:
+			return nil, d.Errf("unknown subdirective for the revocation verifier: %s", h.Val())
 		}
+
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zachgalvin/caddy-revocation-validator.git
+module github.com/zachgalvin/caddy-revocation-validator
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zachgalvin/caddy-revocation-validator
+module github.com/gr33nbl00d/caddy-revocation-validator
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gr33nbl00d/caddy-revocation-validator
+module github.com/zachgalvin/caddy-revocation-validator.git
 
 go 1.19
 


### PR DESCRIPTION
With version 2.8.0 of Caddy, the Caddyfile adapter will have the ability to load client_auth verifier modules with [PR 6022](https://github.com/caddyserver/caddy/pull/6022), so I was hoping to add the below code to allow this module to work with the Caddyfile adapter as well. 

Open issue on this here: #2 

Not sure if there are other thoughts for how to do this, but the below works well!